### PR TITLE
Use lvgl:master:HEAD for CI build.

### DIFF
--- a/.github/workflows/compile-examples-private.yml
+++ b/.github/workflows/compile-examples-private.yml
@@ -52,7 +52,7 @@ jobs:
           libraries: |
             # Install the library from the local path.
             - source-path: ./
-            - name: lvgl
+            - source-url: https://github.com/lvgl/lvgl.git
             # Additional library dependencies can be listed here.
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |


### PR DESCRIPTION
This change is made in order to verify the correct working of all examples during various refactoring operations.
However, this change needs to be reverted in order to allow verification if lvgl has indeed released a working 8.1 library version.