### PR TITLE
Bugfix: Invalid comparison and assignment due to motor id's ranging from 1-6.

### DIFF
--- a/src/lib/motors/SmartServo.cpp
+++ b/src/lib/motors/SmartServo.cpp
@@ -219,10 +219,10 @@ void SmartServoClass::synchronize() {
   
   for (int i = MIN_MOTOR_ID; i <= MAX_MOTOR_ID; i++) {
     _txPacket.payload[index++] = i;
-    _txPacket.payload[index++] = _targetPosition[i-1] >>8;
-    _txPacket.payload[index++] = _targetPosition[i-1];
-    _txPacket.payload[index++] = _targetSpeed[i-1]>>8;
-    _txPacket.payload[index++] = _targetSpeed[i-1];
+    _txPacket.payload[index++] = _targetPosition[idToArrayIndex(i)] >>8;
+    _txPacket.payload[index++] = _targetPosition[idToArrayIndex(i)];
+    _txPacket.payload[index++] = _targetSpeed[idToArrayIndex(i)]>>8;
+    _txPacket.payload[index++] = _targetSpeed[idToArrayIndex(i)];
   }
   sendPacket();
   mutex.unlock();

--- a/src/lib/motors/SmartServo.h
+++ b/src/lib/motors/SmartServo.h
@@ -89,6 +89,7 @@ private:
   static int constexpr MAX_MOTOR_ID = 6;
 
   inline bool isValidId(int const id) const { return ((id >= MIN_MOTOR_ID) && (id <= MAX_MOTOR_ID)); }
+  inline int  idToArrayIndex(int const id) const { return (id - 1); }
 
   int      calcChecksum    ();
   void     sendPacket      ();


### PR DESCRIPTION
Fix: Motor IDs go from 1 to 6, but values are stored in arrays with a max size of 6.

This error was not observable while having configured for 7 motors (because '<' comparison was used) but is now obviously a problem.