### PR TITLE
Disable power debug output.

### DIFF
--- a/src/Braccio++.cpp
+++ b/src/Braccio++.cpp
@@ -34,7 +34,8 @@
  * DEFINES
  **************************************************************************************/
 
-#define BRACCIO_POWER_DEBUG_ENABLE
+/* Uncommenting this line enables debug output of the USB Power Delivery library. */
+//#define BRACCIO_POWER_DEBUG_ENABLE
 
 /**************************************************************************************
  * FUNCTION DECLARATION


### PR DESCRIPTION
Seeing all the debug output would likely confuse the typical user of this library. It can be re-enabled by un-commenting `BRACCIO_POWER_DEBUG_ENABLE`.