### PR TITLE
Revert #15.

### DIFF
--- a/.github/workflows/compile-examples-private.yml
+++ b/.github/workflows/compile-examples-private.yml
@@ -52,7 +52,7 @@ jobs:
           libraries: |
             # Install the library from the local path.
             - source-path: ./
-            - source-url: https://github.com/lvgl/lvgl.git
+            - name: lvgl
             # Additional library dependencies can be listed here.
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |


### PR DESCRIPTION
Since [lvgl:v8.2.0](https://github.com/lvgl/lvgl/issues/2957) is now working again for Arduino we can directly use the latest released version instead of lvgl:master:HEAD. (Also see notes in #15).