### PR TITLE
Switch to variant of "Compile Examples" workflow for public repos

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -4,13 +4,13 @@ name: Compile Examples
 on:
   push:
     paths:
-      - ".github/workflows/compile-examples-private.ya?ml"
+      - ".github/workflows/compile-examples.ya?ml"
       - "library.properties"
       - "examples/**"
       - "src/**"
   pull_request:
     paths:
-      - ".github/workflows/compile-examples-private.ya?ml"
+      - ".github/workflows/compile-examples.ya?ml"
       - "library.properties"
       - "examples/**"
       - "src/**"
@@ -22,8 +22,6 @@ on:
 
 env:
   SKETCHES_REPORTS_PATH: sketches-reports
-  SKETCHES_REPORTS_ARTIFACT_NAME: sketches-reports
-
 jobs:
   build:
     name: ${{ matrix.board.fqbn }}
@@ -65,26 +63,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
-
-  report-size-deltas:
-    needs: build
-    # Run even if some compilations failed.
-    if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download sketches reports artifact
-        id: download-artifact
-        continue-on-error: true # If compilation failed for all boards then there are no artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
-
-      - name: Comment size deltas report to PR
-        uses: arduino/report-size-deltas@v1
-        # If actions/download-artifact failed, there are no artifacts to report from.
-        if: steps.download-artifact.outcome == 'success'
-        with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.ya?ml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ==========================
 
 [![Check Arduino status](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/check-arduino.yml)
-[![Compile Examples status](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/compile-examples-private.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/compile-examples-private.yml)
+[![Compile Examples status](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/compile-examples.yml)
 [![Spell Check status](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/actions/workflows/spell-check.yml)
 
 This library allows you to control and interact with the 6 DOF Braccio++ robot arm.


### PR DESCRIPTION
Initial development of the project was done in a private repository. In that environment, the most efficient configuration of the workflow is done by running [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) from a job in the same workflow, and so the workflow was configured that way.

However, that configuration is not suitable for use in a public repository. The reason is that the deltas report comment requires a GitHub access token with write permissions and [the token does not have such permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) when the "Compile Examples" workflow is triggered by events in a pull request from a fork. For this reason, it is now necessary to run the `arduino/report-size-deltas` action from a dedicated scheduled workflow, which will always have write permissions.