### PR TITLE
Fix: Capture a new start value - otherwise the loop will terminate prematurely due to a wrong timeout value.

### DIFF
--- a/examples/Tools/Factory_Set_Initial_Servo_Position/Factory_Set_Initial_Servo_Position.ino
+++ b/examples/Tools/Factory_Set_Initial_Servo_Position/Factory_Set_Initial_Servo_Position.ino
@@ -52,7 +52,6 @@ bool set_initial_servo_position(int const id, float const target_angle)
   auto isTimeout = [](unsigned long const start) -> bool { return ((millis() - start) > 2000); };
 
   auto start = millis();
-
   Serial.print("Connecting .... ");
   for (; !Braccio.get(id).connected() && !isTimeout(start); delay(10)) { }
   if (!isTimeout(start))
@@ -82,6 +81,7 @@ bool set_initial_servo_position(int const id, float const target_angle)
 
   static float constexpr EPSILON = 2.0f;
 
+  start = millis();
   for ( float current_angle = Braccio.get(id).position();
        !isTargetAngleReached(EPSILON) && !isTimeout(start);)
   {


### PR DESCRIPTION
Better solution than c05e72dce00f72d95830aa5a7ca43f12b87cceb0 CC @facchinm .