### PR TITLE
Enhance controlling manually braccio

### DIFF
--- a/examples/Controlling_Manually_Braccio/AppState.cpp
+++ b/examples/Controlling_Manually_Braccio/AppState.cpp
@@ -171,12 +171,12 @@ State * PinchState::handle_OnEnter()
 
 State * PinchState::handle_OnLeft()
 {
-  gripper.move().to(gripper.position() + 10.0f).in(10ms);
+  gripper.move().to(gripper.position() + 2.5f);
   return this;
 }
 
 State * PinchState::handle_OnRight()
 {
-  gripper.move().to(gripper.position() - 10.0f).in(10ms);
+  gripper.move().to(gripper.position() - 2.5f);
   return this;
 }

--- a/examples/Controlling_Manually_Braccio/AppState.cpp
+++ b/examples/Controlling_Manually_Braccio/AppState.cpp
@@ -131,25 +131,25 @@ State * WristState::handle_OnEnter()
 
 State * WristState::handle_OnUp()
 {
-  wristRoll.move().to(wristRoll.position() + 5.0f);
+  wristPitch.move().to(wristPitch.position() + 5.0f);
   return this;
 }
 
 State * WristState::handle_OnDown()
 {
-  wristRoll.move().to(wristRoll.position() - 5.0f);
+  wristPitch.move().to(wristPitch.position() - 5.0f);
   return this;
 }
 
 State * WristState::handle_OnLeft()
 {
-  wristPitch.move().to(wristPitch.position() + 5.0f);
+  wristRoll.move().to(wristRoll.position() + 10.0f);
   return this;
 }
 
 State * WristState::handle_OnRight()
 {
-  wristPitch.move().to(wristPitch.position() - 5.0f);
+  wristRoll.move().to(wristRoll.position() - 10.0f);
   return this;
 }
 

--- a/examples/Controlling_Manually_Braccio/AppState.cpp
+++ b/examples/Controlling_Manually_Braccio/AppState.cpp
@@ -7,10 +7,22 @@
 #include <Braccio++.h>
 
 /**************************************************************************************
+ * TYPEDEF
+ **************************************************************************************/
+
+enum BUTTONS {
+  BTN_UP = 1,
+  BTN_DOWN = 7,
+  BTN_LEFT = 3,
+  BTN_RIGHT = 5,
+};
+
+/**************************************************************************************
  * EXTERN
  **************************************************************************************/
 
 extern lv_obj_t * label;
+extern lv_obj_t * direction_btnm;
 
 /**************************************************************************************
  * GLOBAL VARIABLES
@@ -67,6 +79,16 @@ ElbowState::ElbowState()
 {
   Braccio.lvgl_lock();
   lv_label_set_text(label, "Elbow");
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_LEFT,  LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
+  Braccio.lvgl_unlock();
+}
+
+ElbowState::~ElbowState()
+{
+  Braccio.lvgl_lock();
+  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_LEFT,  LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
   Braccio.lvgl_unlock();
 }
 
@@ -129,6 +151,16 @@ PinchState::PinchState()
 {
   Braccio.lvgl_lock();
   lv_label_set_text(label, "Pinch");
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_UP,   LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_HIDDEN);
+  Braccio.lvgl_unlock();
+}
+
+PinchState::~PinchState()
+{
+  Braccio.lvgl_lock();
+  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_UP,   LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_HIDDEN);
   Braccio.lvgl_unlock();
 }
 

--- a/examples/Controlling_Manually_Braccio/AppState.cpp
+++ b/examples/Controlling_Manually_Braccio/AppState.cpp
@@ -6,197 +6,145 @@
 
 #include <Braccio++.h>
 
-extern lv_obj_t * label;
-extern lv_obj_t * direction_btnm;
-
-enum BUTTONS {
-  BTN_UP = 1,
-  BTN_DOWN = 7,
-  BTN_LEFT = 3,
-  BTN_RIGHT = 5,
-};
-
 /**************************************************************************************
- * State
+ * EXTERN
  **************************************************************************************/
 
-State * State::handle_OnButtonDownPressed()
-{
-  Braccio.lvgl_lock();
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
-  Braccio.lvgl_unlock();
-  return this;
-}
+extern lv_obj_t * label;
 
-State * State::handle_OnButtonDownReleased()
-{
-  Braccio.lvgl_lock();
-  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
-  Braccio.lvgl_unlock();
-  return this;
-}
+/**************************************************************************************
+ * GLOBAL VARIABLES
+ **************************************************************************************/
+
+static auto gripper    = Braccio.get(1);
+static auto wristRoll  = Braccio.get(2);
+static auto wristPitch = Braccio.get(3);
+static auto elbow      = Braccio.get(4);
+static auto shoulder   = Braccio.get(5);
+static auto base       = Braccio.get(6);
 
 /**************************************************************************************
  * ShoulderState
  **************************************************************************************/
 
-void ShoulderState::onEnter()
+ShoulderState::ShoulderState()
 {
   Braccio.lvgl_lock();
   lv_label_set_text(label, "Shoulder");
   Braccio.lvgl_unlock();
 }
 
-void ShoulderState::onExit()
-{
-
-}
-
-State * ShoulderState::handle_OnButtonDownPressed()
-{
-  State::handle_OnButtonDownPressed();
-  return this;
-}
-
-State * ShoulderState::handle_OnButtonDownReleased()
-{
-  State::handle_OnButtonDownReleased();
-  return this;
-}
-
-State * ShoulderState::handle_OnButtonUp()
-{
-  return this;
-}
-
-State * ShoulderState::handle_OnButtonLeft()
-{
-  return this;
-}
-
-State * ShoulderState::handle_OnButtonRight()
-{
-  return this;
-}
-
-State * ShoulderState::handle_OnButtonEnter()
+State * ShoulderState::handle_OnEnter()
 {
   return new ElbowState();
+}
+
+State * ShoulderState::handle_OnUp()
+{
+  return this;
+}
+
+State * ShoulderState::handle_OnDown()
+{
+  return this;
+}
+
+State * ShoulderState::handle_OnLeft()
+{
+  return this;
+}
+
+State * ShoulderState::handle_OnRight()
+{
+  return this;
 }
 
 /**************************************************************************************
  * ElbowState
  **************************************************************************************/
 
-void ElbowState::onEnter()
+ElbowState::ElbowState()
 {
   Braccio.lvgl_lock();
   lv_label_set_text(label, "Elbow");
   Braccio.lvgl_unlock();
 }
 
-void ElbowState::onExit()
-{
-
-}
-
-State * ElbowState::handle_OnButtonDownPressed()
-{
-  State::handle_OnButtonDownPressed();
-  return this;
-}
-
-State * ElbowState::handle_OnButtonDownReleased()
-{
-  State::handle_OnButtonDownReleased();
-  return this;
-}
-
-State * ElbowState::handle_OnButtonUp()
+State * ElbowState::handle_OnEnter()
 {
   return new WristState();
 }
 
-State * ElbowState::handle_OnButtonEnter()
+State * ElbowState::handle_OnUp()
 {
-  return new WristState();
+  return this;
+}
+
+State * ElbowState::handle_OnDown()
+{
+  return this;
 }
 
 /**************************************************************************************
  * WristState
  **************************************************************************************/
 
-void WristState::onEnter()
+WristState::WristState()
 {
   Braccio.lvgl_lock();
   lv_label_set_text(label, "Wrist");
   Braccio.lvgl_unlock();
 }
 
-void WristState::onExit()
-{
-
-}
-
-State * WristState::handle_OnButtonDownPressed()
-{
-  State::handle_OnButtonDownPressed();
-  return this;
-}
-
-State * WristState::handle_OnButtonDownReleased()
-{
-  State::handle_OnButtonDownReleased();
-  return this;
-}
-
-State * WristState::handle_OnButtonUp()
-{
-  return this;
-}
-
-State * WristState::handle_OnButtonLeft()
-{
-  return this;
-}
-
-State * WristState::handle_OnButtonRight()
-{
-  return this;
-}
-
-State * WristState::handle_OnButtonEnter()
+State * WristState::handle_OnEnter()
 {
   return new PinchState();
+}
+
+State * WristState::handle_OnUp()
+{
+  return this;
+}
+
+State * WristState::handle_OnDown()
+{
+  return this;
+}
+
+State * WristState::handle_OnLeft()
+{
+  return this;
+}
+
+State * WristState::handle_OnRight()
+{
+  return this;
 }
 
 /**************************************************************************************
  * PinchState
  **************************************************************************************/
 
-void PinchState::onEnter()
+PinchState::PinchState()
 {
   Braccio.lvgl_lock();
   lv_label_set_text(label, "Pinch");
   Braccio.lvgl_unlock();
 }
 
-void PinchState::onExit()
-{
-
-}
-
-State * PinchState::handle_OnButtonLeft()
-{
-  return this;
-}
-
-State * PinchState::handle_OnButtonRight()
-{
-  return this;
-}
-
-State * PinchState::handle_OnButtonEnter()
+State * PinchState::handle_OnEnter()
 {
   return new ShoulderState();
+}
+
+State * PinchState::handle_OnLeft()
+{
+  gripper.move().to(gripper.position() + 10.0f).in(10ms);
+  return this;
+}
+
+State * PinchState::handle_OnRight()
+{
+  gripper.move().to(gripper.position() - 10.0f).in(10ms);
+  return this;
 }

--- a/examples/Controlling_Manually_Braccio/AppState.cpp
+++ b/examples/Controlling_Manually_Braccio/AppState.cpp
@@ -53,21 +53,25 @@ State * ShoulderState::handle_OnEnter()
 
 State * ShoulderState::handle_OnUp()
 {
+  shoulder.move().to(shoulder.position() + 5.0f);
   return this;
 }
 
 State * ShoulderState::handle_OnDown()
 {
+  shoulder.move().to(shoulder.position() - 5.0f);
   return this;
 }
 
 State * ShoulderState::handle_OnLeft()
 {
+  base.move().to(base.position() + 5.0f);
   return this;
 }
 
 State * ShoulderState::handle_OnRight()
 {
+  base.move().to(base.position() - 5.0f);
   return this;
 }
 
@@ -99,11 +103,13 @@ State * ElbowState::handle_OnEnter()
 
 State * ElbowState::handle_OnUp()
 {
+  elbow.move().to(elbow.position() + 5.0f);
   return this;
 }
 
 State * ElbowState::handle_OnDown()
 {
+  elbow.move().to(elbow.position() - 5.0f);
   return this;
 }
 
@@ -125,21 +131,25 @@ State * WristState::handle_OnEnter()
 
 State * WristState::handle_OnUp()
 {
+  wristRoll.move().to(wristRoll.position() + 5.0f);
   return this;
 }
 
 State * WristState::handle_OnDown()
 {
+  wristRoll.move().to(wristRoll.position() - 5.0f);
   return this;
 }
 
 State * WristState::handle_OnLeft()
 {
+  wristPitch.move().to(wristPitch.position() + 5.0f);
   return this;
 }
 
 State * WristState::handle_OnRight()
 {
+  wristPitch.move().to(wristPitch.position() - 5.0f);
   return this;
 }
 
@@ -171,12 +181,12 @@ State * PinchState::handle_OnEnter()
 
 State * PinchState::handle_OnLeft()
 {
-  gripper.move().to(gripper.position() + 2.5f);
+  gripper.move().to(gripper.position() + 5.0f);
   return this;
 }
 
 State * PinchState::handle_OnRight()
 {
-  gripper.move().to(gripper.position() - 2.5f);
+  gripper.move().to(gripper.position() - 5.0f);
   return this;
 }

--- a/examples/Controlling_Manually_Braccio/AppState.cpp
+++ b/examples/Controlling_Manually_Braccio/AppState.cpp
@@ -1,0 +1,202 @@
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "AppState.h"
+
+#include <Braccio++.h>
+
+extern lv_obj_t * label;
+extern lv_obj_t * direction_btnm;
+
+enum BUTTONS {
+  BTN_UP = 1,
+  BTN_DOWN = 7,
+  BTN_LEFT = 3,
+  BTN_RIGHT = 5,
+};
+
+/**************************************************************************************
+ * State
+ **************************************************************************************/
+
+State * State::handle_OnButtonDownPressed()
+{
+  Braccio.lvgl_lock();
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
+  Braccio.lvgl_unlock();
+  return this;
+}
+
+State * State::handle_OnButtonDownReleased()
+{
+  Braccio.lvgl_lock();
+  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
+  Braccio.lvgl_unlock();
+  return this;
+}
+
+/**************************************************************************************
+ * ShoulderState
+ **************************************************************************************/
+
+void ShoulderState::onEnter()
+{
+  Braccio.lvgl_lock();
+  lv_label_set_text(label, "Shoulder");
+  Braccio.lvgl_unlock();
+}
+
+void ShoulderState::onExit()
+{
+
+}
+
+State * ShoulderState::handle_OnButtonDownPressed()
+{
+  State::handle_OnButtonDownPressed();
+  return this;
+}
+
+State * ShoulderState::handle_OnButtonDownReleased()
+{
+  State::handle_OnButtonDownReleased();
+  return this;
+}
+
+State * ShoulderState::handle_OnButtonUp()
+{
+  return this;
+}
+
+State * ShoulderState::handle_OnButtonLeft()
+{
+  return this;
+}
+
+State * ShoulderState::handle_OnButtonRight()
+{
+  return this;
+}
+
+State * ShoulderState::handle_OnButtonEnter()
+{
+  return new ElbowState();
+}
+
+/**************************************************************************************
+ * ElbowState
+ **************************************************************************************/
+
+void ElbowState::onEnter()
+{
+  Braccio.lvgl_lock();
+  lv_label_set_text(label, "Elbow");
+  Braccio.lvgl_unlock();
+}
+
+void ElbowState::onExit()
+{
+
+}
+
+State * ElbowState::handle_OnButtonDownPressed()
+{
+  State::handle_OnButtonDownPressed();
+  return this;
+}
+
+State * ElbowState::handle_OnButtonDownReleased()
+{
+  State::handle_OnButtonDownReleased();
+  return this;
+}
+
+State * ElbowState::handle_OnButtonUp()
+{
+  return new WristState();
+}
+
+State * ElbowState::handle_OnButtonEnter()
+{
+  return new WristState();
+}
+
+/**************************************************************************************
+ * WristState
+ **************************************************************************************/
+
+void WristState::onEnter()
+{
+  Braccio.lvgl_lock();
+  lv_label_set_text(label, "Wrist");
+  Braccio.lvgl_unlock();
+}
+
+void WristState::onExit()
+{
+
+}
+
+State * WristState::handle_OnButtonDownPressed()
+{
+  State::handle_OnButtonDownPressed();
+  return this;
+}
+
+State * WristState::handle_OnButtonDownReleased()
+{
+  State::handle_OnButtonDownReleased();
+  return this;
+}
+
+State * WristState::handle_OnButtonUp()
+{
+  return this;
+}
+
+State * WristState::handle_OnButtonLeft()
+{
+  return this;
+}
+
+State * WristState::handle_OnButtonRight()
+{
+  return this;
+}
+
+State * WristState::handle_OnButtonEnter()
+{
+  return new PinchState();
+}
+
+/**************************************************************************************
+ * PinchState
+ **************************************************************************************/
+
+void PinchState::onEnter()
+{
+  Braccio.lvgl_lock();
+  lv_label_set_text(label, "Pinch");
+  Braccio.lvgl_unlock();
+}
+
+void PinchState::onExit()
+{
+
+}
+
+State * PinchState::handle_OnButtonLeft()
+{
+  return this;
+}
+
+State * PinchState::handle_OnButtonRight()
+{
+  return this;
+}
+
+State * PinchState::handle_OnButtonEnter()
+{
+  return new ShoulderState();
+}

--- a/examples/Controlling_Manually_Braccio/AppState.h
+++ b/examples/Controlling_Manually_Braccio/AppState.h
@@ -66,7 +66,7 @@ class ElbowState : public State
 {
 public:
            ElbowState();
-  virtual ~ElbowState() { }
+  virtual ~ElbowState();
 protected:
   virtual State * handle_OnEnter() override;
   virtual State * handle_OnUp   () override;
@@ -91,7 +91,7 @@ class PinchState : public State
 {
 public:
            PinchState();
-  virtual ~PinchState() { }
+  virtual ~PinchState();
 protected:
   virtual State * handle_OnEnter() override;
   virtual State * handle_OnLeft () override;

--- a/examples/Controlling_Manually_Braccio/AppState.h
+++ b/examples/Controlling_Manually_Braccio/AppState.h
@@ -1,0 +1,147 @@
+#ifndef APP_STATE_H_
+#define APP_STATE_H_
+
+/**************************************************************************************
+ * TYPEDEF
+ **************************************************************************************/
+
+enum class EventSource
+{
+  Button_DownPressed, Button_DownReleased, Button_Up, Button_Left, Button_Right, Button_Enter
+};
+
+enum class StateName
+{
+  Shoulder, Elbow, Wrist, Pinch
+};
+
+/**************************************************************************************
+ * CLASS DECLARATION
+ **************************************************************************************/
+
+class State
+{
+public:
+  virtual ~State() { }
+  virtual void onEnter() { }
+  virtual void onExit() { }
+  virtual StateName name() = 0;
+  State * update(EventSource const evt_src)
+  {
+    State * next_state = this;
+    switch (evt_src)
+    {
+      case EventSource::Button_DownPressed:  next_state = handle_OnButtonDownPressed();  break;
+      case EventSource::Button_DownReleased: next_state = handle_OnButtonDownReleased(); break;
+
+      case EventSource::Button_Up:    next_state = handle_OnButtonUp();       break;
+      case EventSource::Button_Left:  next_state = handle_OnButtonLeft(); break;
+      case EventSource::Button_Right: next_state = handle_OnButtonRight();    break;
+      case EventSource::Button_Enter: next_state = handle_OnButtonEnter();    break;
+    }
+    return next_state;
+  }
+
+protected:
+  virtual State * handle_OnButtonDownPressed();
+  virtual State * handle_OnButtonDownReleased();
+  virtual State * handle_OnButtonUp()    { return this; }
+  virtual State * handle_OnButtonLeft()  { return this; }
+  virtual State * handle_OnButtonRight() { return this; }
+  virtual State * handle_OnButtonEnter() { return this; }
+};
+
+class ShoulderState : public State
+{
+public:
+  virtual ~ShoulderState() { }
+  virtual StateName name() override { return StateName::Shoulder; }
+  virtual void onEnter() override;
+  virtual void onExit() override;
+
+protected:
+  virtual State * handle_OnButtonDownPressed() override;
+  virtual State * handle_OnButtonDownReleased() override;
+  virtual State * handle_OnButtonUp()    override;
+  virtual State * handle_OnButtonLeft()  override;
+  virtual State * handle_OnButtonRight() override;
+  virtual State * handle_OnButtonEnter() override;
+};
+
+class ElbowState : public State
+{
+public:
+  virtual ~ElbowState() { }
+  virtual StateName name() override { return StateName::Elbow; }
+  virtual void onEnter() override;
+  virtual void onExit() override;
+
+protected:
+  virtual State * handle_OnButtonDownPressed() override;
+  virtual State * handle_OnButtonDownReleased() override;
+  virtual State * handle_OnButtonUp()    override;
+  virtual State * handle_OnButtonEnter() override;
+};
+
+class WristState : public State
+{
+public:
+  virtual ~WristState() { }
+  virtual StateName name() override { return StateName::Wrist; }
+  virtual void onEnter() override;
+  virtual void onExit() override;
+
+protected:
+  virtual State * handle_OnButtonDownPressed() override;
+  virtual State * handle_OnButtonDownReleased() override;
+  virtual State * handle_OnButtonUp()    override;
+  virtual State * handle_OnButtonLeft()  override;
+  virtual State * handle_OnButtonRight() override;
+  virtual State * handle_OnButtonEnter() override;
+};
+
+class PinchState : public State
+{
+public:
+  virtual ~PinchState() { }
+  virtual StateName name() override { return StateName::Pinch; }
+  virtual void onEnter() override;
+  virtual void onExit() override;
+
+protected:
+  virtual State * handle_OnButtonLeft()  override;
+  virtual State * handle_OnButtonRight() override;
+  virtual State * handle_OnButtonEnter() override;
+};
+
+class ControlApp
+{
+public:
+  ControlApp()
+  : _state{nullptr}
+  { }
+
+  void update(EventSource const evt_src)
+  {
+    if (!_state)
+    {
+      _state = new ShoulderState();
+      _state->onEnter();
+    }
+    
+    State * next_state = _state->update(evt_src);
+      
+    if (next_state->name() != _state->name())
+    {
+      _state->onExit();
+      delete _state;
+      _state = next_state;
+      _state->onEnter();
+    }    
+  }
+
+private:
+  State * _state;
+};
+
+#endif /* APP_STATE_H_ */

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -10,7 +10,6 @@
  * DEFINES
  **************************************************************************************/
 
-// Colors
 #define COLOR_TEAL       0x00878F
 #define COLOR_LIGHT_TEAL 0x62AEB2
 #define COLOR_YELLOW     0xE5AD24
@@ -27,66 +26,27 @@ enum BUTTONS {
   BTN_RIGHT = 5,
 };
 
-static const char *direction_btnm_map[] = {" ", LV_SYMBOL_UP, " ", "\n",
-                                        LV_SYMBOL_LEFT, " ", LV_SYMBOL_RIGHT, "\n",
-                                        " ", LV_SYMBOL_DOWN, " ", "\0"};
+/**************************************************************************************
+ * CONSTANTS
+ **************************************************************************************/
+
+static float const HOME_POS[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 90.0};
+static const char *DIRECTION_BTNM_MAP[] = {" ", LV_SYMBOL_UP, " ", "\n",
+                                           LV_SYMBOL_LEFT, " ", LV_SYMBOL_RIGHT, "\n",
+                                           " ", LV_SYMBOL_DOWN, " ", "\0"};
 
 /**************************************************************************************
  * GLOBAL VARIABLES
  **************************************************************************************/
 
-// Variables
-static float const HOME_POS[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 90.0};
-
-lv_obj_t * direction_btnm;  // Direction button matrix
-lv_obj_t * label; // Label
+lv_obj_t * direction_btnm;
+lv_obj_t * label;
 
 ManualControlApp app;
 
-// Screens functions
-
-void directionScreen(void)
-{
-  Braccio.lvgl_lock();
-  
-  static lv_style_t style_bg;
-  lv_style_init(&style_bg);
-  lv_style_set_bg_color(&style_bg, lv_color_white());
-
-  static lv_style_t style_btn;
-  lv_style_init(&style_btn);
-  lv_style_set_bg_color(&style_btn, lv_color_hex(COLOR_LIGHT_TEAL));
-  lv_style_set_text_color(&style_btn, lv_color_white());
-
-  direction_btnm = lv_btnmatrix_create(lv_scr_act());
-  lv_obj_set_size(direction_btnm, 240, 240);
-  lv_btnmatrix_set_map(direction_btnm, direction_btnm_map);
-  lv_obj_align(direction_btnm, LV_ALIGN_CENTER, 0, 0);
-
-  lv_obj_add_style(direction_btnm, &style_bg, 0);
-  lv_obj_add_style(direction_btnm, &style_btn, LV_PART_ITEMS);
-
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 0, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 1, LV_BTNMATRIX_CTRL_DISABLED);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 2, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 3, LV_BTNMATRIX_CTRL_DISABLED);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 4, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 5, LV_BTNMATRIX_CTRL_DISABLED);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 6, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 7, LV_BTNMATRIX_CTRL_DISABLED);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 8, LV_BTNMATRIX_CTRL_HIDDEN);
-
-  lv_btnmatrix_set_one_checked(direction_btnm, true);
-  lv_btnmatrix_set_selected_btn(direction_btnm, 1);
-
-  label = lv_label_create(lv_scr_act());
-  lv_obj_set_width(label, 240);
-  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
-  lv_label_set_text(label, "");
-  
-  Braccio.lvgl_unlock();
-}
+/**************************************************************************************
+ * SETUP/LOOP
+ **************************************************************************************/
 
 void setup()
 {
@@ -95,7 +55,7 @@ void setup()
   if (Braccio.begin(directionScreen))
   {
     /* Configure Braccio. */
-    Braccio.speed(MEDIUM);
+    Braccio.speed(speed_grade_t(150)/*MEDIUM*/);
     /* Move to home position. */
     Braccio.moveTo(HOME_POS[0], HOME_POS[1], HOME_POS[2], HOME_POS[3], HOME_POS[4], HOME_POS[5]);
     delay(500);
@@ -142,6 +102,53 @@ void loop()
         app.update(Button::Right);
     }
   }
+}
+
+/**************************************************************************************
+ * FUNCTIONS
+ **************************************************************************************/
+
+void directionScreen(void)
+{
+  Braccio.lvgl_lock();
+  
+  static lv_style_t style_bg;
+  lv_style_init(&style_bg);
+  lv_style_set_bg_color(&style_bg, lv_color_white());
+
+  static lv_style_t style_btn;
+  lv_style_init(&style_btn);
+  lv_style_set_bg_color(&style_btn, lv_color_hex(COLOR_LIGHT_TEAL));
+  lv_style_set_text_color(&style_btn, lv_color_white());
+
+  direction_btnm = lv_btnmatrix_create(lv_scr_act());
+  lv_obj_set_size(direction_btnm, 240, 240);
+  lv_btnmatrix_set_map(direction_btnm, DIRECTION_BTNM_MAP);
+  lv_obj_align(direction_btnm, LV_ALIGN_CENTER, 0, 0);
+
+  lv_obj_add_style(direction_btnm, &style_bg, 0);
+  lv_obj_add_style(direction_btnm, &style_btn, LV_PART_ITEMS);
+
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 0, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 1, LV_BTNMATRIX_CTRL_DISABLED);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 2, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 3, LV_BTNMATRIX_CTRL_DISABLED);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 4, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 5, LV_BTNMATRIX_CTRL_DISABLED);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 6, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 7, LV_BTNMATRIX_CTRL_DISABLED);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 8, LV_BTNMATRIX_CTRL_HIDDEN);
+
+  lv_btnmatrix_set_one_checked(direction_btnm, true);
+  lv_btnmatrix_set_selected_btn(direction_btnm, 1);
+
+  label = lv_label_create(lv_scr_act());
+  lv_obj_set_width(label, 240);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+  lv_label_set_text(label, "");
+  
+  Braccio.lvgl_unlock();
 }
 
 void handle_ButtonPressedReleased()

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -19,24 +19,6 @@
  * TYPEDEF
  **************************************************************************************/
 
-enum states {
-  SHOULDER,
-  ELBOW,
-  WRIST,
-  PINCH
-};
-
-// Values of clicked input keys returned by Braccio.getKey() function (defined inside the library).
-enum KEYS
-{
-  UP = 4,
-  DOWN = 5,
-  LEFT = 1,
-  RIGHT = 2,
-  CLICK = 3, // click of joystick
-  ENTER = 6,
-};
-
 // IDs of the displayed directional UI buttons
 enum BUTTONS {
   BTN_UP = 1,
@@ -54,128 +36,12 @@ static const char *direction_btnm_map[] = {" ", LV_SYMBOL_UP, " ", "\n",
  **************************************************************************************/
 
 // Variables
-float homePos[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 190.0};
-float angles[6]; // All motors current angles
-
-// Braccio ++ joints
-auto gripper    = Braccio.get(1);
-auto wristRoll  = Braccio.get(2);
-auto wristPitch = Braccio.get(3);
-auto elbow      = Braccio.get(4);
-auto shoulder   = Braccio.get(5);
-auto base       = Braccio.get(6);
-
-char * jointsPair[] = {"Shoulder", "Elbow", "Wrist", "Pinch"};
-
-int state = SHOULDER;
+static float const HOME_POS[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 90.0};
 
 lv_obj_t * direction_btnm;  // Direction button matrix
 lv_obj_t * label; // Label
 
 ManualControlApp app;
-
-// Function
-void moveJoints(uint32_t btnID) {
-  switch (state) {
-    case SHOULDER:
-      switch (btnID) {
-        case 4: shoulder.move().to(angles[4] - 10.0); break;
-        case 1: base.move().to(angles[5] - 10.0);    break;
-        case 2: base.move().to(angles[5] + 10.0);    break;
-        case 5: shoulder.move().to(angles[4] + 10.0); break;
-        default: break;
-      }
-      break;
-    case ELBOW:
-      switch (btnID) {
-        case 4: elbow.move().to(angles[3] - 10.0); break;
-        case 5: elbow.move().to(angles[3] + 10.0); break;
-        default: break;
-      }
-      break;
-    case WRIST:
-      switch (btnID) {
-        case 4: wristPitch.move().to(angles[2] - 10.0); break;
-        case 1: wristRoll.move().to(angles[1] - 10.0);  break;
-        case 2: wristRoll.move().to(angles[1] + 10.0);  break;
-        case 5: wristPitch.move().to(angles[2] + 10.0); break;
-        default: break;
-      }
-      break;
-    case PINCH:
-      switch (btnID) {
-        case 1: gripper.move().to(angles[0] + 10.0); break;
-        case 2: gripper.move().to(angles[0] - 10.0); break;      
-        default: break;
-      }
-    default:
-      break;
-  }
-}
-
-void updateButtons(uint32_t key)
-{
-  if (key == UP){
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_selected_btn(direction_btnm, BTN_UP);
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_CHECKED);
-    Braccio.lvgl_unlock();
-  }
-  else if (key == DOWN){
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_selected_btn(direction_btnm, BTN_DOWN);
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
-    Braccio.lvgl_unlock();
-  }
-  else if (key == LEFT) {
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_selected_btn(direction_btnm, BTN_LEFT);
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_CHECKED);
-    Braccio.lvgl_unlock();
-  }
-  else if (key == RIGHT){
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_selected_btn(direction_btnm, BTN_RIGHT);
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_CHECKED);
-    Braccio.lvgl_unlock();
-  }
-  else {
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_selected_btn(direction_btnm, NULL);
-    Braccio.lvgl_unlock();
-  }
-/*
-  if (state == ELBOW){
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_HIDDEN);
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
-    Braccio.lvgl_unlock();
-  }
-  else if (state == PINCH){
-    Braccio.lvgl_lock();
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_HIDDEN);
-    lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_HIDDEN);
-    Braccio.lvgl_unlock();
-  }
-  else{
-    Braccio.lvgl_lock();
-    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_HIDDEN);
-    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_HIDDEN);
-    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_HIDDEN);
-    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
-    Braccio.lvgl_unlock();
-  }
-  */
-  /*
-  Braccio.lvgl_lock();
-  lv_label_set_text(label, jointsPair[state]);
-  Braccio.lvgl_unlock();
-  */
-}
-
-// Event Handlers
-
-
 
 // Screens functions
 
@@ -217,7 +83,7 @@ void directionScreen(void)
   lv_obj_set_width(label, 240);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
-  lv_label_set_text(label, jointsPair[state]);
+  lv_label_set_text(label, "");
   
   Braccio.lvgl_unlock();
 }
@@ -231,8 +97,10 @@ void setup()
     /* Configure Braccio. */
     Braccio.speed(MEDIUM);
     /* Move to home position. */
-    Braccio.moveTo(homePos[0], homePos[1], homePos[2], homePos[3], homePos[4], homePos[5]);
+    Braccio.moveTo(HOME_POS[0], HOME_POS[1], HOME_POS[2], HOME_POS[3], HOME_POS[4], HOME_POS[5]);
     delay(500);
+    /* Init state. */
+    app.update(Button::None);
     /* Enable buttons. */
     Braccio.lvgl_lock();
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, 1, LV_BTNMATRIX_CTRL_DISABLED);
@@ -241,8 +109,6 @@ void setup()
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, 7, LV_BTNMATRIX_CTRL_DISABLED);
     Braccio.lvgl_unlock();
   }
-
-  app.update(Button::None);
 }
 
 void loop()

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -8,7 +8,7 @@
 #define COLOR_YELLOW     0xE5AD24
 
 // Variables
-float homePos[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 90.0};
+float homePos[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 190.0};
 float angles[6]; // All motors current angles
 
 // Braccio ++ joints
@@ -25,7 +25,8 @@ String selectedJoints = "Shoulder";
 enum states {
   SHOULDER,
   ELBOW,
-  WRIST
+  WRIST,
+  PINCH
 };
 
 int state = SHOULDER;
@@ -73,6 +74,12 @@ void moveJoints(uint32_t btnID) {
         default: break;
       }
       break;
+    case PINCH:
+      switch (btnID) {
+        case 1: gripper.move().to(angles[0] + 10.0); break;
+        case 2: gripper.move().to(angles[0] - 10.0); break;      
+        default: break;
+      }
     default:
       break;
 
@@ -95,7 +102,7 @@ static void eventHandlerDirectional(lv_event_t * e) {
       //mainMenu(); // Load motor menu screen
       //lv_obj_del(directional); // Delete the object
       state++;
-      if (state > WRIST) {
+      if (state > PINCH) {
         state = SHOULDER; // restart from the shoulder
       }
     }

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -40,28 +40,28 @@ lv_obj_t * directional; // Direction button matrix
 void moveJoints(uint32_t btnID) {
   if (selectedJoints == "Shoulder") {
     switch (btnID) {
-      case 1: shoulder.move().to(angles[4] - 10.0); break;
-      case 3: base.move().to(angles[5] - 10.0);    break;
-      case 5: base.move().to(angles[5] + 10.0);    break;
-      case 7: shoulder.move().to(angles[4] + 10.0); break;
+      case 4: shoulder.move().to(angles[4] - 10.0); break;
+      case 1: base.move().to(angles[5] - 10.0);    break;
+      case 2: base.move().to(angles[5] + 10.0);    break;
+      case 5: shoulder.move().to(angles[4] + 10.0); break;
       default: break;
     }
   }
 
   if (selectedJoints == "Elbow") {
     switch (btnID) {
-      case 1: elbow.move().to(angles[3] - 10.0); break;
-      case 7: elbow.move().to(angles[3] + 10.0); break;
+      case 4: elbow.move().to(angles[3] - 10.0); break;
+      case 5: elbow.move().to(angles[3] + 10.0); break;
       default: break;
     }
   }
 
   if (selectedJoints == "Wrist") {
     switch (btnID) {
-      case 1: wristPitch.move().to(angles[2] - 10.0); break;
-      case 3: wristRoll.move().to(angles[1] - 10.0);  break;
-      case 5: wristRoll.move().to(angles[1] + 10.0);  break;
-      case 7: wristPitch.move().to(angles[2] + 10.0); break;
+      case 4: wristPitch.move().to(angles[2] - 10.0); break;
+      case 1: wristRoll.move().to(angles[1] - 10.0);  break;
+      case 2: wristRoll.move().to(angles[1] + 10.0);  break;
+      case 5: wristPitch.move().to(angles[2] + 10.0); break;
       default: break;
     }
   }
@@ -83,18 +83,15 @@ static void eventHandlerDirectional(lv_event_t * e) {
   lv_obj_t * obj = lv_event_get_target(e);
 
   if (code == LV_EVENT_KEY) {
-    uint32_t pressed_key = Braccio.getKey();
+  uint32_t pressed_key = Braccio.getKey();
+  Braccio.positions(angles);
+  delay(5);
+  moveJoints(pressed_key);
 
     if (pressed_key == BUTTON_ENTER) {
       mainMenu(); // Load motor menu screen
       lv_obj_del(directional); // Delete the object
     }
-  }
-  if (code == LV_EVENT_PRESSING) {
-    uint32_t id = lv_btnmatrix_get_selected_btn(obj);
-    Braccio.positions(angles);
-    delay(5);
-    moveJoints(id);
   }
 }
 

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -146,7 +146,7 @@ static void eventHandlerDirectional(lv_event_t * e) {
   if (code == LV_EVENT_KEY){
   pressed_key = Braccio.getKey();
 
-    if (pressed_key == ENTER){
+    if (pressed_key == ENTER || pressed_key == CLICK){
       state++; // Index the next joints in the states enum array
       
       if (state > PINCH){

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -248,6 +248,15 @@ void loop()
   }
   prev_joystick_pressed_enter = curr_joystick_pressed_enter;
 
+  /* SELECT */
+
+  static bool prev_joystick_pressed_select = false;
+  bool const curr_joystick_pressed_select = Braccio.isJoystickPressed_SELECT();
+  if (!prev_joystick_pressed_select && curr_joystick_pressed_select) {
+    app.update(Button::Enter);
+  }
+  prev_joystick_pressed_select = curr_joystick_pressed_select;
+
   /* DOWN */
 
   static bool prev_joystick_pressed_down = false;

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -80,15 +80,6 @@ void moveJoints(uint32_t btnID) {
 }
 
 // Event Handlers
-static void eventHandlerMenu(lv_event_t * e) {
-  lv_obj_t * obj = lv_event_get_target(e);
-  uint32_t id = lv_btnmatrix_get_selected_btn(obj);
-
-  selectedJoints = jointsPair[id];
-
-  directionScreen();
-  lv_obj_del(btnm);
-}
 
 static void eventHandlerDirectional(lv_event_t * e) {
   lv_event_code_t code = lv_event_get_code(e);
@@ -141,8 +132,6 @@ void mainMenu() {
   lv_btnmatrix_set_one_checked(btnm, true);
   lv_btnmatrix_set_selected_btn(btnm, 0);
 
-  lv_obj_add_event_cb(btnm, eventHandlerMenu, LV_EVENT_PRESSED, NULL);
-
   Braccio.connectJoystickTo(btnm);
 }
 
@@ -175,7 +164,7 @@ void directionScreen(void)
   lv_btnmatrix_set_btn_ctrl(directional, 7, LV_BTNMATRIX_CTRL_CHECKABLE);
   lv_btnmatrix_set_btn_ctrl(directional, 8, LV_BTNMATRIX_CTRL_HIDDEN);
 
-  if (selectedJoints == "Elbow") {
+  if (state == ELBOW) {
     lv_btnmatrix_set_btn_ctrl(directional, 3, LV_BTNMATRIX_CTRL_HIDDEN);
     lv_btnmatrix_set_btn_ctrl(directional, 5, LV_BTNMATRIX_CTRL_HIDDEN);
   }
@@ -185,12 +174,12 @@ void directionScreen(void)
 
   lv_obj_add_event_cb(directional, eventHandlerDirectional, LV_EVENT_ALL, NULL);
 
-  delay(50);
-  Braccio.connectJoystickTo(btnm);
+  // delay(50);
+  Braccio.connectJoystickTo(directional);
 }
 
 void setup() {
-  Braccio.begin(mainMenu);
+  Braccio.begin(directionScreen);
   delay(500); // Waits for the Braccio initialization
 
   Braccio.speed(SLOW);

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -174,7 +174,7 @@ void directionScreen(void)
 
   lv_obj_add_event_cb(directional, eventHandlerDirectional, LV_EVENT_ALL, NULL);
 
-  // delay(50);
+  delay(50);
   Braccio.connectJoystickTo(directional);
 }
 

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -101,47 +101,70 @@ void moveJoints(uint32_t btnID) {
 void updateButtons(uint32_t key)
 {
   if (key == UP){
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_selected_btn(direction_btnm, BTN_UP);
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_CHECKED);
+    Braccio.lvgl_unlock();
   }
   else if (key == DOWN){
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_selected_btn(direction_btnm, BTN_DOWN);
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
+    Braccio.lvgl_unlock();
   }
   else if (key == LEFT) {
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_selected_btn(direction_btnm, BTN_LEFT);
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_CHECKED);
+    Braccio.lvgl_unlock();
   }
   else if (key == RIGHT){
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_selected_btn(direction_btnm, BTN_RIGHT);
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_CHECKED);
+    Braccio.lvgl_unlock();
   }
   else {
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_selected_btn(direction_btnm, NULL);
+    Braccio.lvgl_unlock();
   }
 
   if (state == ELBOW){
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_HIDDEN);
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
+    Braccio.lvgl_unlock();
   }
   else if (state == PINCH){
+    Braccio.lvgl_lock();
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_HIDDEN);
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_HIDDEN);
+    Braccio.lvgl_unlock();
   }
   else{
+    Braccio.lvgl_lock();
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_HIDDEN);
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_HIDDEN);
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_HIDDEN);
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
+    Braccio.lvgl_unlock();
   }
+  
+  Braccio.lvgl_lock();
   lv_label_set_text(label, jointsPair[state]);
+  Braccio.lvgl_unlock();
 }
 
 // Event Handlers
 
 static void eventHandlerDirectional(lv_event_t * e) {
+  Braccio.lvgl_lock();
+  
   lv_event_code_t code = lv_event_get_code(e);
   lv_obj_t * obj = lv_event_get_target(e);
+  
+  Braccio.lvgl_unlock();
 
   if (code == LV_EVENT_KEY){
   pressed_key = Braccio.getKey();
@@ -164,6 +187,8 @@ static void eventHandlerDirectional(lv_event_t * e) {
 
 void directionScreen(void)
 {
+  Braccio.lvgl_lock();
+  
   static lv_style_t style_bg;
   lv_style_init(&style_bg);
   lv_style_set_bg_color(&style_bg, lv_color_white());
@@ -201,6 +226,8 @@ void directionScreen(void)
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
   lv_label_set_text(label, jointsPair[state]);
+  
+  Braccio.lvgl_unlock();
 
   delay(50);
   Braccio.connectJoystickTo(direction_btnm);
@@ -221,11 +248,16 @@ void loop()
 {
   pressed_key= Braccio.getKey();
  if (pressed_key == 0) {
-if(pressed_key != last_pressed_key){
-  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_CHECKED);
+  if(pressed_key != last_pressed_key){
+    Braccio.lvgl_lock();
+    
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_CHECKED);
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_CHECKED);
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_CHECKED);
+    
+    Braccio.lvgl_unlock();
+    
     delay(50);  
 
     }

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -55,7 +55,7 @@ void setup()
   if (Braccio.begin(directionScreen))
   {
     /* Configure Braccio. */
-    Braccio.speed(speed_grade_t(150)/*MEDIUM*/);
+    Braccio.speed(speed_grade_t(120)/*MEDIUM*/);
     /* Move to home position. */
     Braccio.moveTo(HOME_POS[0], HOME_POS[1], HOME_POS[2], HOME_POS[3], HOME_POS[4], HOME_POS[5]);
     delay(500);
@@ -84,11 +84,11 @@ void loop()
     }
   }
 
-  /* Execute every 100 ms. */
+  /* Execute every 50 ms. */
   {
     static auto prev = millis();
     auto const now = millis();
-    if ((now - prev) > 100)
+    if ((now - prev) > 50)
     {
       prev = now;
 

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -9,7 +9,7 @@
 
 // Variables
 String selectedJoints;
-float homePos[6] = {160.0, 150.0, 220.0, 220.0, 100.0, 180.0};
+float homePos[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 90.0};
 float angles[6]; // All motors current angles
 
 // Braccio ++ joints

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -32,19 +32,12 @@ enum states {
 int state = SHOULDER;
 
 
-static const char * btnm_map[] = {"Shoulder", "\n",
-                                  "Elbow", "\n",
-                                  "Wrist", "\0"
-                                 };
-
 static const char * directional_map[] = {" ", LV_SYMBOL_UP, " ", "\n",
                                          LV_SYMBOL_LEFT, " ", LV_SYMBOL_RIGHT, "\n",
                                          " ", LV_SYMBOL_DOWN, " ", "\0"
                                         };
 
-lv_obj_t * btnm; // Joints button matrix
 lv_obj_t * directional; // Direction button matrix
-
 
 // Function
 void moveJoints(uint32_t btnID) {
@@ -110,37 +103,6 @@ static void eventHandlerDirectional(lv_event_t * e) {
 }
 
 // Screens functions
-void mainMenu() {
-  static lv_style_t style_bg;
-  lv_style_init(&style_bg);
-  lv_style_set_bg_color(&style_bg, lv_color_white());
-
-  static lv_style_t style_btn;
-  lv_style_init(&style_btn);
-  lv_style_set_bg_color(&style_btn, lv_color_hex(COLOR_YELLOW));
-  lv_style_set_border_color(&style_btn, lv_color_hex(COLOR_LIGHT_TEAL));
-  lv_style_set_border_width(&style_btn, 2);
-  lv_style_set_text_color(&style_btn, lv_color_hex(COLOR_TEAL));
-  lv_style_set_text_letter_space(&style_btn, 8);
-
-  btnm = lv_btnmatrix_create(lv_scr_act());
-  lv_obj_set_size(btnm, 240, 240);
-  lv_btnmatrix_set_map(btnm, btnm_map);
-  lv_obj_align(btnm, LV_ALIGN_CENTER, 0, 0);
-
-  lv_obj_add_style(btnm, &style_bg, 0);
-  lv_obj_add_style(btnm, &style_btn, LV_PART_ITEMS);
-
-  lv_btnmatrix_set_btn_ctrl(btnm, 0, LV_BTNMATRIX_CTRL_CHECKABLE);
-  lv_btnmatrix_set_btn_ctrl(btnm, 1, LV_BTNMATRIX_CTRL_CHECKABLE);
-  lv_btnmatrix_set_btn_ctrl(btnm, 2, LV_BTNMATRIX_CTRL_CHECKABLE);
-  lv_btnmatrix_set_btn_ctrl(btnm, 3, LV_BTNMATRIX_CTRL_CHECKABLE);
-
-  lv_btnmatrix_set_one_checked(btnm, true);
-  lv_btnmatrix_set_selected_btn(btnm, 0);
-
-  Braccio.connectJoystickTo(btnm);
-}
 
 void directionScreen(void)
 {

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -1,0 +1,191 @@
+#include <Braccio++.h>
+
+#define BUTTON_ENTER         6
+
+// Colors
+#define COLOR_TEAL       0x00878F
+#define COLOR_LIGHT_TEAL 0x62AEB2
+#define COLOR_YELLOW     0xE5AD24
+
+// Variables
+String selectedJoints;
+float homePos[6] = {160.0, 150.0, 220.0, 220.0, 100.0, 180.0};
+float angles[6]; // All motors current angles
+
+// Braccio ++ joints
+auto gripper    = Braccio.get(1);
+auto wristRoll  = Braccio.get(2);
+auto wristPitch = Braccio.get(3);
+auto elbow      = Braccio.get(4);
+auto shoulder   = Braccio.get(5);
+auto base       = Braccio.get(6);
+
+String jointsPair[] = {"Shoulder", "Elbow", "Wrist"};
+
+static const char * btnm_map[] = {"Shoulder", "\n",
+                                  "Elbow", "\n",
+                                  "Wrist", "\0"
+                                 };
+
+static const char * directional_map[] = {" ", LV_SYMBOL_UP, " ", "\n",
+                                         LV_SYMBOL_LEFT, " ", LV_SYMBOL_RIGHT, "\n",
+                                         " ", LV_SYMBOL_DOWN, " ", "\0"
+                                        };
+
+lv_obj_t * btnm; // Joints button matrix
+lv_obj_t * directional; // Direction button matrix
+
+
+// Function
+void moveJoints(uint32_t btnID) {
+  if (selectedJoints == "Shoulder") {
+    switch (btnID) {
+      case 1: shoulder.move().to(angles[4] - 10.0); break;
+      case 3: base.move().to(angles[5] - 10.0);    break;
+      case 5: base.move().to(angles[5] + 10.0);    break;
+      case 7: shoulder.move().to(angles[4] + 10.0); break;
+      default: break;
+    }
+  }
+
+  if (selectedJoints == "Elbow") {
+    switch (btnID) {
+      case 1: elbow.move().to(angles[3] - 10.0); break;
+      case 7: elbow.move().to(angles[3] + 10.0); break;
+      default: break;
+    }
+  }
+
+  if (selectedJoints == "Wrist") {
+    switch (btnID) {
+      case 1: wristPitch.move().to(angles[2] - 10.0); break;
+      case 3: wristRoll.move().to(angles[1] - 10.0);  break;
+      case 5: wristRoll.move().to(angles[1] + 10.0);  break;
+      case 7: wristPitch.move().to(angles[2] + 10.0); break;
+      default: break;
+    }
+  }
+}
+
+// Event Handlers
+static void eventHandlerMenu(lv_event_t * e) {
+  lv_obj_t * obj = lv_event_get_target(e);
+  uint32_t id = lv_btnmatrix_get_selected_btn(obj);
+
+  selectedJoints = jointsPair[id];
+
+  directionScreen();
+  lv_obj_del(btnm);
+}
+
+static void eventHandlerDirectional(lv_event_t * e) {
+  lv_event_code_t code = lv_event_get_code(e);
+  lv_obj_t * obj = lv_event_get_target(e);
+
+  if (code == LV_EVENT_KEY) {
+    uint32_t pressed_key = Braccio.getKey();
+
+    if (pressed_key == BUTTON_ENTER) {
+      mainMenu(); // Load motor menu screen
+      lv_obj_del(directional); // Delete the object
+    }
+  }
+  if (code == LV_EVENT_PRESSING) {
+    uint32_t id = lv_btnmatrix_get_selected_btn(obj);
+    Braccio.positions(angles);
+    delay(5);
+    moveJoints(id);
+  }
+}
+
+// Screens functions
+void mainMenu() {
+  static lv_style_t style_bg;
+  lv_style_init(&style_bg);
+  lv_style_set_bg_color(&style_bg, lv_color_white());
+
+  static lv_style_t style_btn;
+  lv_style_init(&style_btn);
+  lv_style_set_bg_color(&style_btn, lv_color_hex(COLOR_YELLOW));
+  lv_style_set_border_color(&style_btn, lv_color_hex(COLOR_LIGHT_TEAL));
+  lv_style_set_border_width(&style_btn, 2);
+  lv_style_set_text_color(&style_btn, lv_color_hex(COLOR_TEAL));
+  lv_style_set_text_letter_space(&style_btn, 8);
+
+  btnm = lv_btnmatrix_create(lv_scr_act());
+  lv_obj_set_size(btnm, 240, 240);
+  lv_btnmatrix_set_map(btnm, btnm_map);
+  lv_obj_align(btnm, LV_ALIGN_CENTER, 0, 0);
+
+  lv_obj_add_style(btnm, &style_bg, 0);
+  lv_obj_add_style(btnm, &style_btn, LV_PART_ITEMS);
+
+  lv_btnmatrix_set_btn_ctrl(btnm, 0, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(btnm, 1, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(btnm, 2, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(btnm, 3, LV_BTNMATRIX_CTRL_CHECKABLE);
+
+  lv_btnmatrix_set_one_checked(btnm, true);
+  lv_btnmatrix_set_selected_btn(btnm, 0);
+
+  lv_obj_add_event_cb(btnm, eventHandlerMenu, LV_EVENT_PRESSED, NULL);
+
+  Braccio.connectJoystickTo(btnm);
+}
+
+void directionScreen(void)
+{
+  static lv_style_t style_bg;
+  lv_style_init(&style_bg);
+  lv_style_set_bg_color(&style_bg, lv_color_white());
+
+  static lv_style_t style_btn;
+  lv_style_init(&style_btn);
+  lv_style_set_bg_color(&style_btn, lv_color_hex(COLOR_LIGHT_TEAL));
+  lv_style_set_text_color(&style_btn, lv_color_white());
+
+  directional = lv_btnmatrix_create(lv_scr_act());
+  lv_obj_set_size(directional, 240, 240);
+  lv_btnmatrix_set_map(directional, directional_map);
+  lv_obj_align(directional, LV_ALIGN_CENTER, 0, 0);
+
+  lv_obj_add_style(directional, &style_bg, 0);
+  lv_obj_add_style(directional, &style_btn, LV_PART_ITEMS);
+
+  lv_btnmatrix_set_btn_ctrl(directional, 0, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(directional, 1, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(directional, 2, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(directional, 3, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(directional, 4, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(directional, 5, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(directional, 6, LV_BTNMATRIX_CTRL_HIDDEN);
+  lv_btnmatrix_set_btn_ctrl(directional, 7, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(directional, 8, LV_BTNMATRIX_CTRL_HIDDEN);
+
+  if (selectedJoints == "Elbow") {
+    lv_btnmatrix_set_btn_ctrl(directional, 3, LV_BTNMATRIX_CTRL_HIDDEN);
+    lv_btnmatrix_set_btn_ctrl(directional, 5, LV_BTNMATRIX_CTRL_HIDDEN);
+  }
+
+  lv_btnmatrix_set_one_checked(directional, true);
+  lv_btnmatrix_set_selected_btn(directional, 1);
+
+  lv_obj_add_event_cb(directional, eventHandlerDirectional, LV_EVENT_ALL, NULL);
+
+  delay(50);
+  Braccio.connectJoystickTo(btnm);
+}
+
+void setup() {
+  Braccio.begin(mainMenu);
+  delay(500); // Waits for the Braccio initialization
+
+  Braccio.speed(SLOW);
+
+  Braccio.moveTo(homePos[0], homePos[1], homePos[2], homePos[3], homePos[4], homePos[5]);
+  delay(500);
+}
+
+void loop() {
+
+}

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -229,7 +229,7 @@ void setup()
   if (Braccio.begin(directionScreen))
   {
     /* Configure Braccio. */
-    Braccio.speed(SLOW);
+    Braccio.speed(MEDIUM);
     /* Move to home position. */
     Braccio.moveTo(homePos[0], homePos[1], homePos[2], homePos[3], homePos[4], homePos[5]);
     delay(500);
@@ -313,16 +313,22 @@ void loop()
   }
   prev_joystick_pressed_right = curr_joystick_pressed_right;
 
-  if (Braccio.isJoystickPressed_UP())
-    app.update(Button::Up);
-  if (Braccio.isJoystickPressed_DOWN())
-    app.update(Button::Down);
-  if (Braccio.isJoystickPressed_LEFT())
-    app.update(Button::Left);
-  if (Braccio.isJoystickPressed_RIGHT())
-    app.update(Button::Right);
 
-  delay(10);
+  static auto prev = millis();
+  auto const now = millis();
+  if ((now - prev) > 100)
+  {
+    prev = now;
+
+    if (Braccio.isJoystickPressed_UP())
+      app.update(Button::Up);
+    if (Braccio.isJoystickPressed_DOWN())
+      app.update(Button::Down);
+    if (Braccio.isJoystickPressed_LEFT())
+      app.update(Button::Left);
+    if (Braccio.isJoystickPressed_RIGHT())
+      app.update(Button::Right);
+  }
 }
 
 void handle_OnButtonDownPressed()

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -8,7 +8,6 @@
 #define COLOR_YELLOW     0xE5AD24
 
 // Variables
-String selectedJoints;
 float homePos[6] = {157.5, 157.5, 157.5, 157.5, 157.5, 90.0};
 float angles[6]; // All motors current angles
 
@@ -21,6 +20,16 @@ auto shoulder   = Braccio.get(5);
 auto base       = Braccio.get(6);
 
 String jointsPair[] = {"Shoulder", "Elbow", "Wrist"};
+String selectedJoints = "Shoulder";
+
+enum states {
+  SHOULDER,
+  ELBOW,
+  WRIST
+};
+
+int state = SHOULDER;
+
 
 static const char * btnm_map[] = {"Shoulder", "\n",
                                   "Elbow", "\n",
@@ -38,32 +47,35 @@ lv_obj_t * directional; // Direction button matrix
 
 // Function
 void moveJoints(uint32_t btnID) {
-  if (selectedJoints == "Shoulder") {
-    switch (btnID) {
-      case 4: shoulder.move().to(angles[4] - 10.0); break;
-      case 1: base.move().to(angles[5] - 10.0);    break;
-      case 2: base.move().to(angles[5] + 10.0);    break;
-      case 5: shoulder.move().to(angles[4] + 10.0); break;
-      default: break;
-    }
-  }
+  switch (state) {
+    case SHOULDER:
+      switch (btnID) {
+        case 4: shoulder.move().to(angles[4] - 10.0); break;
+        case 1: base.move().to(angles[5] - 10.0);    break;
+        case 2: base.move().to(angles[5] + 10.0);    break;
+        case 5: shoulder.move().to(angles[4] + 10.0); break;
+        default: break;
+      }
+      break;
+    case ELBOW:
+      switch (btnID) {
+        case 4: elbow.move().to(angles[3] - 10.0); break;
+        case 5: elbow.move().to(angles[3] + 10.0); break;
+        default: break;
+      }
+      break;
+    case WRIST:
+      switch (btnID) {
+        case 4: wristPitch.move().to(angles[2] - 10.0); break;
+        case 1: wristRoll.move().to(angles[1] - 10.0);  break;
+        case 2: wristRoll.move().to(angles[1] + 10.0);  break;
+        case 5: wristPitch.move().to(angles[2] + 10.0); break;
+        default: break;
+      }
+      break;
+    default:
+      break;
 
-  if (selectedJoints == "Elbow") {
-    switch (btnID) {
-      case 4: elbow.move().to(angles[3] - 10.0); break;
-      case 5: elbow.move().to(angles[3] + 10.0); break;
-      default: break;
-    }
-  }
-
-  if (selectedJoints == "Wrist") {
-    switch (btnID) {
-      case 4: wristPitch.move().to(angles[2] - 10.0); break;
-      case 1: wristRoll.move().to(angles[1] - 10.0);  break;
-      case 2: wristRoll.move().to(angles[1] + 10.0);  break;
-      case 5: wristPitch.move().to(angles[2] + 10.0); break;
-      default: break;
-    }
   }
 }
 
@@ -89,8 +101,12 @@ static void eventHandlerDirectional(lv_event_t * e) {
   moveJoints(pressed_key);
 
     if (pressed_key == BUTTON_ENTER) {
-      mainMenu(); // Load motor menu screen
-      lv_obj_del(directional); // Delete the object
+      //mainMenu(); // Load motor menu screen
+      //lv_obj_del(directional); // Delete the object
+      state++;
+      if (state > WRIST) {
+        state = SHOULDER; // restart from the shoulder
+      }
     }
   }
 }
@@ -184,5 +200,4 @@ void setup() {
 }
 
 void loop() {
-
 }

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -201,13 +201,13 @@ void directionScreen(void)
   lv_obj_add_style(direction_btnm, &style_btn, LV_PART_ITEMS);
 
   lv_btnmatrix_set_btn_ctrl(direction_btnm, 0, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 1, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 1, LV_BTNMATRIX_CTRL_DISABLED);
   lv_btnmatrix_set_btn_ctrl(direction_btnm, 2, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 3, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 3, LV_BTNMATRIX_CTRL_DISABLED);
   lv_btnmatrix_set_btn_ctrl(direction_btnm, 4, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 5, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 5, LV_BTNMATRIX_CTRL_DISABLED);
   lv_btnmatrix_set_btn_ctrl(direction_btnm, 6, LV_BTNMATRIX_CTRL_HIDDEN);
-  lv_btnmatrix_set_btn_ctrl(direction_btnm, 7, LV_BTNMATRIX_CTRL_CHECKABLE);
+  lv_btnmatrix_set_btn_ctrl(direction_btnm, 7, LV_BTNMATRIX_CTRL_DISABLED);
   lv_btnmatrix_set_btn_ctrl(direction_btnm, 8, LV_BTNMATRIX_CTRL_HIDDEN);
 
   lv_btnmatrix_set_one_checked(direction_btnm, true);
@@ -226,15 +226,23 @@ void setup()
 {
   Serial.begin(115200);
 
-  Braccio.begin(directionScreen);
-  delay(500); // Waits for the Braccio initialization
+  if (Braccio.begin(directionScreen))
+  {
+    /* Configure Braccio. */
+    Braccio.speed(SLOW);
+    /* Move to home position. */
+    Braccio.moveTo(homePos[0], homePos[1], homePos[2], homePos[3], homePos[4], homePos[5]);
+    delay(500);
+    /* Enable buttons. */
+    Braccio.lvgl_lock();
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, 1, LV_BTNMATRIX_CTRL_DISABLED);
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, 3, LV_BTNMATRIX_CTRL_DISABLED);
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, 5, LV_BTNMATRIX_CTRL_DISABLED);
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, 7, LV_BTNMATRIX_CTRL_DISABLED);
+    Braccio.lvgl_unlock();
+  }
 
   app.update(Button::None);
-
-  Braccio.speed(SLOW);
-
-  Braccio.moveTo(homePos[0], homePos[1], homePos[2], homePos[3], homePos[4], homePos[5]);
-  delay(500);
 }
 
 void loop()

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -144,7 +144,7 @@ void updateButtons(uint32_t key)
     lv_btnmatrix_set_selected_btn(direction_btnm, NULL);
     Braccio.lvgl_unlock();
   }
-
+/*
   if (state == ELBOW){
     Braccio.lvgl_lock();
     lv_btnmatrix_set_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_HIDDEN);
@@ -165,6 +165,7 @@ void updateButtons(uint32_t key)
     lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_HIDDEN);
     Braccio.lvgl_unlock();
   }
+  */
   /*
   Braccio.lvgl_lock();
   lv_label_set_text(label, jointsPair[state]);
@@ -238,15 +239,14 @@ void setup()
 
 void loop()
 {
-  if (Braccio.isButtonPressed_ENTER()) {
-    static auto prev_enter_event = millis();
-    auto const now = millis();
-    if ((now - prev_enter_event) > 200 && Braccio.isButtonPressed_ENTER())
-    {
-      prev_enter_event = now;
-      app.update(Button::Enter);
-    }
+  /* ENTER */
+
+  static bool prev_joystick_pressed_enter = false;
+  bool const curr_joystick_pressed_enter = Braccio.isButtonPressed_ENTER();
+  if (!prev_joystick_pressed_enter && curr_joystick_pressed_enter) {
+    app.update(Button::Enter);
   }
+  prev_joystick_pressed_enter = curr_joystick_pressed_enter;
 
   /* DOWN */
 

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -247,6 +247,39 @@ void setup()
 
 void loop()
 {
+  /* Execute every 10 ms. */
+  {
+    static auto prev = millis();
+    auto const now = millis();
+    if ((now - prev) > 10)
+    {
+      prev = now;
+      handle_ButtonPressedReleased();
+    }
+  }
+
+  /* Execute every 100 ms. */
+  {
+    static auto prev = millis();
+    auto const now = millis();
+    if ((now - prev) > 100)
+    {
+      prev = now;
+
+      if (Braccio.isJoystickPressed_UP())
+        app.update(Button::Up);
+      if (Braccio.isJoystickPressed_DOWN())
+        app.update(Button::Down);
+      if (Braccio.isJoystickPressed_LEFT())
+        app.update(Button::Left);
+      if (Braccio.isJoystickPressed_RIGHT())
+        app.update(Button::Right);
+    }
+  }
+}
+
+void handle_ButtonPressedReleased()
+{
   /* ENTER */
 
   static bool prev_joystick_pressed_enter = false;
@@ -312,23 +345,6 @@ void loop()
     handle_OnButtonRightReleased();
   }
   prev_joystick_pressed_right = curr_joystick_pressed_right;
-
-
-  static auto prev = millis();
-  auto const now = millis();
-  if ((now - prev) > 100)
-  {
-    prev = now;
-
-    if (Braccio.isJoystickPressed_UP())
-      app.update(Button::Up);
-    if (Braccio.isJoystickPressed_DOWN())
-      app.update(Button::Down);
-    if (Braccio.isJoystickPressed_LEFT())
-      app.update(Button::Left);
-    if (Braccio.isJoystickPressed_RIGHT())
-      app.update(Button::Right);
-  }
 }
 
 void handle_OnButtonDownPressed()

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -41,6 +41,7 @@ enum KEYS
 };
 
 uint32_t pressed_key;
+uint32_t last_pressed_key;
 
 
 // IDs of the displayed directional UI buttons
@@ -218,5 +219,16 @@ void setup()
 
 void loop()
 {
+  pressed_key= Braccio.getKey();
+ if (pressed_key == 0) {
+if(pressed_key != last_pressed_key){
+  lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_UP, LV_BTNMATRIX_CTRL_CHECKED);
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_DOWN, LV_BTNMATRIX_CTRL_CHECKED);
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_RIGHT, LV_BTNMATRIX_CTRL_CHECKED);
+    lv_btnmatrix_clear_btn_ctrl(direction_btnm, BTN_LEFT, LV_BTNMATRIX_CTRL_CHECKED);
+    delay(50);  
 
+    }
+  }
+    last_pressed_key=pressed_key;
 }

--- a/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
+++ b/examples/Controlling_Manually_Braccio/Controlling_Manually_Braccio.ino
@@ -196,4 +196,18 @@ void setup() {
 }
 
 void loop() {
+  if (state == ELBOW) {
+    lv_btnmatrix_set_btn_ctrl(directional, 3, LV_BTNMATRIX_CTRL_HIDDEN);
+    lv_btnmatrix_set_btn_ctrl(directional, 5, LV_BTNMATRIX_CTRL_HIDDEN);
+  }
+  else if (state == PINCH) {
+    lv_btnmatrix_set_btn_ctrl(directional, 1, LV_BTNMATRIX_CTRL_HIDDEN);
+    lv_btnmatrix_set_btn_ctrl(directional, 7, LV_BTNMATRIX_CTRL_HIDDEN);
+  }
+  else {
+    lv_btnmatrix_clear_btn_ctrl(directional, 1, LV_BTNMATRIX_CTRL_HIDDEN);
+    lv_btnmatrix_clear_btn_ctrl(directional, 3, LV_BTNMATRIX_CTRL_HIDDEN);
+    lv_btnmatrix_clear_btn_ctrl(directional, 5, LV_BTNMATRIX_CTRL_HIDDEN);
+    lv_btnmatrix_clear_btn_ctrl(directional, 7, LV_BTNMATRIX_CTRL_HIDDEN);
+  }
 }


### PR DESCRIPTION
Enhanced version of the manually-controlling-braccio example:
- Added "PINCH" joints control (braccio grip)
- Switch between joints is now triggered directly by the enter button or joystick click
- A label at the center of the screen shows the current selected joints
- The UI buttons now behave as push buttons, the checked state is triggered while joystick directional inputs are pressed, and revert to default state on joystick release. 
- Removal of the mainMenu screen
- UI buttons availability change accordingly to the selected joints 

Note: since the driver definition and hardware buttons mapping happens inside the library and that only the "KEY_ENTER" lvgl input triggers the LV_EVENT_PRESSED/PRESSING/RELEASED, is not possible to achieve a "push button" behavior without adding a routine in loop that check if Braccio.getKey() has changed to zero in order to remove the checked state. 
The definition of another input driver for this example where each input is identified as KEY_ENTER would make possible to exploit the states of lvgl with all the physical inputs. 