### PR TITLE
Fix: Usage of 'delay()' causes unacceptable large delay between two consecutive RS485 write commands.

### DIFF
--- a/src/lib/motors/SmartServo.cpp
+++ b/src/lib/motors/SmartServo.cpp
@@ -62,7 +62,7 @@ void SmartServoClass::sendPacket()
   _RS485.endTransmission();
   // should now receive an echo of what we just sent
   while (_RS485.available() < len) {
-    delay(100);
+    delayMicroseconds(10);
   }
   // discard the echo
   int i = len;


### PR DESCRIPTION
This change allows for a much faster cadence of write commands.

Compare

![delay](https://user-images.githubusercontent.com/3931733/186119978-37787b43-5a25-49c5-b05e-4c6183c2a689.png)

with

![delayMicroseconds](https://user-images.githubusercontent.com/3931733/186120005-a4e444be-9f49-4c29-bd84-502bf0936a24.png)

!